### PR TITLE
fix: restore delete button

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -129,6 +129,18 @@
     toast(removedSum > 0 ? `ลบแล้ว ${removedSum} ตัว` : 'ไม่มี …');
   }
 
+  // Re-add the button if the chat UI is re-rendered and removes it
+  function observeUI() {
+    if (observeUI._observer) return;
+    const mo = new MutationObserver(() => {
+      if (!document.getElementById('remove-ellipsis-ext__container')) {
+        addUI();
+      }
+    });
+    mo.observe(document.body, { childList: true, subtree: true });
+    observeUI._observer = mo;
+  }
+
   function addUI() {
     if (document.querySelector('#remove-ellipsis-ext__container')) return;
 
@@ -177,6 +189,8 @@
     } else {
       mount.appendChild(box);
     }
+
+    observeUI();
   }
 
   // export ui module


### PR DESCRIPTION
## Summary
- watch for DOM mutations and re-add extension UI if it's removed
- ensure remove ellipsis button stays visible even after SillyTavern re-renders

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b34c8d9ccc8325ab348c5a9680579c