### PR TITLE
Strip trailing spaces after removed ellipsis

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@
     const inlines = [];
     const sk2 = sk1.replace(inlineRegex, m => `@@INLINE${inlines.push(m)-1}@@`);
 
-    const pattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
+    const basePattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
+    const pattern = preserveSpace
+      ? basePattern
+      : new RegExp(`(?:${basePattern.source})[ \t]*`, 'g');
 
     let removed = 0;
     const cleaned = sk2.replace(pattern, (m, offset, str) => {

--- a/test/cleaner.test.js
+++ b/test/cleaner.test.js
@@ -28,5 +28,11 @@ assert.deepStrictEqual(
   { text: 'HelloWorld', removed: 3 }
 );
 
+// Should remove trailing space when not preserving space
+assert.deepStrictEqual(
+  cleanOutsideCode('Hello... World', true, false),
+  { text: 'HelloWorld', removed: 4 }
+);
+
 console.log('Tests passed');
 


### PR DESCRIPTION
## Summary
- Avoid leftover spaces when ellipsis are removed with space preservation disabled
- Add regression test for ellipsis followed by space

## Testing
- `node test/cleaner.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd66c93d088325959328be6ad3fc94