### PR TITLE
Remove ellipsis before quotes or asterisks

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,15 @@
     const inlines = [];
     const sk2 = sk1.replace(inlineRegex, m => `@@INLINE${inlines.push(m)-1}@@`);
 
-    const pattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
-
+    const basePattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
+    const specialPattern = new RegExp(`(?:${basePattern.source})[ \t]*(?=[*"'])`, 'g');
     let removed = 0;
-    const cleaned = sk2.replace(pattern, (m, offset, str) => {
+    const spCleaned = sk2.replace(specialPattern, m => { removed += m.length; return ''; });
+    const pattern = preserveSpace
+      ? basePattern
+      : new RegExp(`(?:${basePattern.source})[ \t]*`, 'g');
+
+    const cleaned = spCleaned.replace(pattern, (m, offset, str) => {
       removed += m.length;
       if (!preserveSpace) return '';
       const prev = str[offset - 1];

--- a/test/cleaner.test.js
+++ b/test/cleaner.test.js
@@ -28,5 +28,23 @@ assert.deepStrictEqual(
   { text: 'HelloWorld', removed: 3 }
 );
 
+// Should remove trailing space when not preserving space
+assert.deepStrictEqual(
+  cleanOutsideCode('Hello... World', true, false),
+  { text: 'HelloWorld', removed: 4 }
+);
+
+// Should remove ellipsis before quotes or asterisks without adding space
+['"', "'", '*'].forEach(sym => {
+  assert.deepStrictEqual(
+    cleanOutsideCode(`Test...${sym}`, true),
+    { text: `Test${sym}`, removed: 3 }
+  );
+  assert.deepStrictEqual(
+    cleanOutsideCode(`Test...${sym}`, true, false),
+    { text: `Test${sym}`, removed: 3 }
+  );
+});
+
 console.log('Tests passed');
 


### PR DESCRIPTION
## Summary
- Avoid leftover spaces when ellipsis appear before quotes or asterisks
- Add regression tests for ellipsis preceding `"`, `'` or `*`

## Testing
- `node test/cleaner.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd66c93d088325959328be6ad3fc94