### PR TITLE
Remove ellipsis before or after quotes or asterisks

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,18 @@
     const inlines = [];
     const sk2 = sk1.replace(inlineRegex, m => `@@INLINE${inlines.push(m)-1}@@`);
 
-    const pattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
-
+    const basePattern = treatTwoDots ? /(?<!\d)\.{2,}(?!\d)|…/g : /(?<!\d)\.{3,}(?!\d)|…/g;
+    const specialPatternAfter = new RegExp(`(?:${basePattern.source})[ \t]*(?=[*"'])`, 'g');
+    const specialPatternBefore = new RegExp(`(?<=[*"'])(?:${basePattern.source})[ \t]*`, 'g');
     let removed = 0;
-    const cleaned = sk2.replace(pattern, (m, offset, str) => {
+    const spCleaned = sk2
+      .replace(specialPatternAfter, m => { removed += m.length; return ''; })
+      .replace(specialPatternBefore, m => { removed += m.length; return ''; });
+    const pattern = preserveSpace
+      ? basePattern
+      : new RegExp(`(?:${basePattern.source})[ \t]*`, 'g');
+
+    const cleaned = spCleaned.replace(pattern, (m, offset, str) => {
       removed += m.length;
       if (!preserveSpace) return '';
       const prev = str[offset - 1];

--- a/test/cleaner.test.js
+++ b/test/cleaner.test.js
@@ -28,5 +28,34 @@ assert.deepStrictEqual(
   { text: 'HelloWorld', removed: 3 }
 );
 
+// Should remove trailing space when not preserving space
+assert.deepStrictEqual(
+  cleanOutsideCode('Hello... World', true, false),
+  { text: 'HelloWorld', removed: 4 }
+);
+
+// Should remove ellipsis before or after quotes or asterisks without adding space
+['"', "'", '*'].forEach(sym => {
+  // Ellipsis before symbol
+  assert.deepStrictEqual(
+    cleanOutsideCode(`Test...${sym}`, true),
+    { text: `Test${sym}`, removed: 3 }
+  );
+  assert.deepStrictEqual(
+    cleanOutsideCode(`Test...${sym}`, true, false),
+    { text: `Test${sym}`, removed: 3 }
+  );
+
+  // Ellipsis after symbol
+  assert.deepStrictEqual(
+    cleanOutsideCode(`${sym}...Test`, true),
+    { text: `${sym}Test`, removed: 3 }
+  );
+  assert.deepStrictEqual(
+    cleanOutsideCode(`${sym}...Test`, true, false),
+    { text: `${sym}Test`, removed: 3 }
+  );
+});
+
 console.log('Tests passed');
 


### PR DESCRIPTION
## Summary
- Strip ellipses when they appear before or after quotes or asterisks without leaving spaces
- Add regression tests for ellipsis adjacent to `"`, `'` or `*`

## Testing
- `node test/cleaner.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd66c93d088325959328be6ad3fc94